### PR TITLE
Remove erroneous LONG_Z_BIT bit in buffer produced by PrepareMessage() 

### DIFF
--- a/RTP_MIDI.cpp
+++ b/RTP_MIDI.cpp
@@ -682,9 +682,8 @@ int CRTP_MIDI::PrepareMessage (TLongMIDIRTPMsg* Buffer, unsigned int TimeStamp)
 	Buffer->Header.Code2=0x61;
 
 	// Long MIDI list : B=1
-	// Deltatime before first byte : Z=1
 	// Phantom = 0 (status byte always included)
-	Buffer->Payload.Control=htons((unsigned short)TailleMIDI|LONG_B_BIT|LONG_Z_BIT);
+	Buffer->Payload.Control=htons((unsigned short)TailleMIDI|LONG_B_BIT);
 
 	Buffer->Header.SequenceNumber=htons(RTPSequence);
 	Buffer->Header.Timestamp=htonl(TimeStamp);


### PR DESCRIPTION
… since there isn't actually any delta-time included in the packet generated by CRTP_MIDI::PrepareMessage()